### PR TITLE
Fix typo for `Info-mode-hook'.

### DIFF
--- a/vi-navigate.el
+++ b/vi-navigate.el
@@ -144,7 +144,7 @@
     man-mode-hook
     apropos-mode-hook
     less-minor-mode-hook
-    info-mode-hook
+    Info-mode-hook
     doc-view-mode-hook
     w3m-mode-hook
     pdf-view-mode-hook


### PR DESCRIPTION
Didn't work for info-mode, had to make this change (Emacs 27.0.50)